### PR TITLE
add token and endpoint options + env

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,11 +22,29 @@ module.exports = function base(url, params, cb) {
     throw new TypeError('github-api-base expects callback to be a function.');
   }
 
-  params = params || {};
+  params = typeof params === 'object' ? params : {};
+
+  var env = process.env;
   var id = params.id;
   var secret = params.secret;
-  params.headers = {'user-agent': 'node.js'};
-  params.url = params.url || (address(url) + auth(id, secret));
+  var token = env.GITHUB_TOKEN || params.token;
+  var endpoint = env.GITHUB_ENDPOINT || params.endpoint;
+  var url = params.url || address(endpoint, url);
+
+  params.headers = {
+    'accept': 'application/vnd.github.v3+json',
+    'user-agent': 'https://github.com/jonschlinkert/github-base'
+  };
+
+  if (token) {
+    params.headers['authorization'] = 'token ' + token;
+  }
+
+  if (id && secret) {
+    url = url + ('?client_id=' + id + '&client_secret=' + secret);
+  }
+
+  params.url = url;
 
   request(params, function (err, res, body) {
     if (err) return cb(err);
@@ -34,10 +52,7 @@ module.exports = function base(url, params, cb) {
   });
 };
 
-function auth(id, secret) {
-  return id && secret ? ('?client_id=' + id + '&client_secret=' + secret) : '';
-}
-
-function address(url) {
-  return 'https://api.github.com/' + url;
+function address(endpoint, url) {
+  endpoint = endpoint || 'https://api.github.com/';
+  return endpoint + url;
 }

--- a/test.js
+++ b/test.js
@@ -28,13 +28,22 @@ describe('base', function () {
       cb();
     });
   });
-
+  it('should work by passing different endpoint', function(cb) {
+    var opts = {
+      endpoint: 'https://api.github.com/repos/'
+    };
+    base('assemble/assemble/contributors', opts, function (err, res) {
+      if (err) console.log(err);
+      res.should.be.an.array;
+      res[0].should.have.properties(['login', 'id', 'avatar_url', 'gravatar_id']);
+      cb();
+    });
+  });
   it('should throw an error when url is not a string:', function () {
     (function () {
       base();
     }).should.throw('github-api-base expects url to be a string.');
   });
-
   it('should throw an error when no callback is given.', function () {
     (function () {
       base('foo');


### PR DESCRIPTION
- add token option
- add endpoint option
- add accept header
- add one test for `endpoint`
- add GITHUB_TOKEN and GITHUB_ENDPOINT env
- update `params` check to be `typeof params === 'object' ? params : {}` it always seems better for me.

not too much, close if you want. main part is possibility for token auth
