### PR TITLE
externalize .requestAll to `request-all`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var util = require('util');
 var utils = require('./lib/utils');
-var request = require('simple-get');
+var request = require('request-all')(require('simple-get'));
 var concat = require('concat-stream');
 var extend = require('extend-shallow');
 var delegate = require('delegate-properties');
@@ -91,7 +91,7 @@ delegate(GitHub.prototype, {
   },
 
   /**
-   * Performs a request using [simple-get][], and then if necessary
+   * Performs a request using [request-all][], and then if necessary
    * requests additional paged content based on the response. Data from
    * all pages are concatenated together and buffered until the last
    * page of data has been retrieved.
@@ -111,7 +111,7 @@ delegate(GitHub.prototype, {
     cb = typeof cb === 'function' ? cb : function noop () {};
     var opts = this.defaults('GET', path, data);
 
-    utils.requestAll(opts, cb);
+    request.requestAll(opts, cb);
     return this;
   },
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var parseLink = require('parse-link-header');
-var request = require('simple-get');
 var extend = require('extend-shallow');
 var mixin = require('mixin-deep');
 var omit = require('object.omit');
@@ -11,29 +9,6 @@ var omit = require('object.omit');
  */
 
 var utils = module.exports;
-
-/**
- * Recursive walk over paged content
- */
-
-utils.requestAll = function (opts, callback) {
-  opts.url = /\?/.test(opts.url) ? opts.url : opts.url + '?per_page=100';
-
-  request.concat(opts, function (err, data, res) {
-    if (err) {return callback(err);}
-    data = JSON.parse(data.toString());
-
-    var links = parseLink(res.headers.link);
-    if (links && links.next) {
-      opts.url = links.next.url;
-      return utils.requestAll(opts, function (err, res, response) {
-        if (err) {return callback(err);}
-        callback(null, data.concat(res), response);
-      });
-    }
-    callback(null, data, res);
-  });
-};
 
 /**
  * Default settings to use for GitHub API requests.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "extend-shallow": "^2.0.1",
     "mixin-deep": "^1.1.3",
     "object.omit": "^2.0.0",
-    "parse-link-header": "^0.4.1",
+    "request-all": "^1.0.0",
     "simple-get": "^1.4.3"
   },
   "devDependencies": {
@@ -51,11 +51,13 @@
       "list": [
         "gists",
         "github-config",
-        "github-contributors"
+        "github-contributors",
+        "request-all"
       ]
     },
     "reflinks": [
       "verb",
+      "request-all",
       "simple-get"
     ]
   }


### PR DESCRIPTION
I've just externalize `.requestAll` method from `lib/utils.js` to standalone lib that can be useful.
That [request-all](https://github.com/tunnckoCore/request-all) lib can be used as wrapper for `simple-get` or as standalone library, so pretty lil' changes was done in that PR. It can handle json and non-json response, also handles url normalization and default headers. 
It has only `parse-link-header` as dependency.

I also update reflinks and related links, but can't find ANY working verb that i can just install and run, so please run verb in your side, lol.

Cheers,
Charlike.
