### PR TITLE
Add param key in the Url when they are added in opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,12 @@ Pull requests and stars are always welcome. For bugs and feature requests, [plea
 
 ### Contributors
 
-| **Commits** | **Contributor** | 
+| **Commits** | **Contributor** |
 | --- | --- |
 | 31 | [jonschlinkert](https://github.com/jonschlinkert) |
 | 7 | [tunnckoCore](https://github.com/tunnckoCore) |
 | 6 | [doowb](https://github.com/doowb) |
+| 1 | [tennisonchan](https://github.com/tennisonchan) |
 
 ### Building docs
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,7 +123,7 @@ utils.defaults = function(options) {
  */
 
 function interpolate(path, options) {
-  var opts = utils.extend({}, options, {params: []});
+  var opts = utils.extend({}, {params: []}, options);
   opts.url = path.replace(/:([\w_]+)/g, function(m, prop) {
     opts.params.push(prop);
     return opts[prop] || prop;
@@ -136,8 +136,13 @@ function interpolate(path, options) {
  */
 
 function createURL(opts) {
-  opts.url += setPrefix(opts.url);
-  opts.url += (new Date()).getTime();
+  if (opts.params.length) {
+    for(let i in opts.params) {
+      let key = opts.params[i];
+      opts.url += setPrefix(opts.url) + `${key}=${opts[key]}`
+    }
+  }
+  opts.url += setPrefix(opts.url) + (new Date()).getTime();
   opts.url = opts.apiurl + opts.url;
   return opts;
 }

--- a/test/request.js
+++ b/test/request.js
@@ -44,6 +44,19 @@ describe('.request', function() {
           cb();
         });
       });
+
+      it('should `GET` the gist with `.request` method since 3017', function(cb) {
+        this.timeout(5000);
+
+        github.request('GET', '/gists', {
+          params: ['since'],
+          since: '3017-10-16T09:12:01.280Z'
+        }, function(err, data, stream) {
+          if (err) return cb(err);
+          assert.strictEqual(data.url, 'https://api.github.com/gists?since=2017-10-16T09:12:01.280Z');
+          cb();
+        });
+      });
     });
 
     describe('PUT /repos', function() {


### PR DESCRIPTION
### Problem
The key `params` is overridden in here https://github.com/jonschlinkert/github-base/blob/master/lib/utils.js#L126

Also, there is no place to add params in the Url.

### Solution
- Change the order of `params` placeholder when extending the options.
- Add param keys in the Url in function `createURL`